### PR TITLE
CASMPET-7142 Limit version of build image at SP5

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -27,7 +27,7 @@
 
 def isStable = env.TAG_NAME != null ? true : false
 def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle'
-def sleVersion = 'latest'
+def sleVersion = '15.5'
 
 pipeline {
 


### PR DESCRIPTION
# Summary

Build image referred as `latest` introduces dependency on `GLIBC_2.34` (because `latest` is a shortcut to `15.6` now). For this package to be installable at SLES15-SP5, we need to limit version at `15.5`.
